### PR TITLE
Add hfsck to package hfsutils.

### DIFF
--- a/hfsutils/PKGBUILD
+++ b/hfsutils/PKGBUILD
@@ -1,7 +1,7 @@
 # POWER Maintainer: Alexander Baldeck <alex.bldck@gmail.com>
 pkgname=hfsutils
 pkgver=3.2.6
-pkgrel=2
+pkgrel=3
 pkgdesc="User space utils for create and check Apple HFS/HFS+ filesystem"
 arch=(x86_64 powerpc64le powerpc64 powerpc riscv64)
 depends=('openssl')
@@ -41,12 +41,14 @@ build() {
   CFLAGS+=' -Wno-implicit-int' \
   ./configure --prefix=${pkgdir}/usr || cat config.log
   make
+  make hfsck/hfsck
 }
 
 package() {
   cd "${pkgname}-${pkgver}"
   mkdir -p ${pkgdir}/usr/{bin,man/man1,share/man}
   make install
+  install -m 755 hfsck/hfsck ${pkgdir}/usr/bin/hfsck
 
   mv ${pkgdir}/usr/man/* ${pkgdir}/usr/share/man/
   rm -rf ${pkgdir}/usr/man


### PR DESCRIPTION
It can be used fix a hfs filesystem created with `hformat` that was not cleanly unmounted.