### PR TITLE
Add support for powerpc64 w/ lightdm and lightdm-gtk-greeter

### DIFF
--- a/lightdm-gtk-greeter/PKGBUILD
+++ b/lightdm-gtk-greeter/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=2.0.9
 pkgrel=1.1
 epoch=1
 pkgdesc='GTK+ greeter for LightDM'
-arch=(x86_64 powerpc64le powerpc riscv64)
+arch=(x86_64 powerpc64le powerpc64 powerpc riscv64)
 url=https://github.com/Xubuntu/lightdm-gtk-greeter
 license=(
   GPL3

--- a/lightdm/PKGBUILD
+++ b/lightdm/PKGBUILD
@@ -11,7 +11,7 @@ pkgver=1.32.0
 pkgrel=6.1
 epoch=1
 pkgdesc='A lightweight display manager'
-arch=(x86_64 powerpc64le powerpc riscv64)
+arch=(x86_64 powerpc64le powerpc64 powerpc riscv64)
 url=https://github.com/canonical/lightdm
 license=(
   # liblightdm is under "LGPL 2 or 3"


### PR DESCRIPTION
These seem to just work for me, I'm not sure why they weren't supported out of the box.  Maybe did they previously break?