### PR TITLE
build bind with jemalloc; compatible with 64k kernels

### DIFF
--- a/bind/.SRCINFO
+++ b/bind/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = bind
 	pkgdesc = A complete, highly portable implementation of the DNS protocol
 	pkgver = 9.20.5
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.isc.org/software/bind/
 	install = bind.install
 	arch = x86_64
@@ -17,6 +17,7 @@ pkgbase = bind
 	depends = e2fsprogs
 	depends = glibc
 	depends = icu
+	depends = jemalloc
 	depends = libedit
 	depends = json-c
 	depends = krb5

--- a/bind/PKGBUILD
+++ b/bind/PKGBUILD
@@ -7,15 +7,15 @@
 
 pkgname=bind
 pkgver=9.20.5
-pkgrel=1
+pkgrel=2
 pkgdesc='A complete, highly portable implementation of the DNS protocol'
 url='https://www.isc.org/software/bind/'
 license=('MPL2')
 arch=(x86_64 powerpc64le powerpc64 powerpc riscv64)
 options=('!emptydirs')
-depends=('bash' 'dnssec-anchors' 'e2fsprogs' 'glibc' 'icu' 'libedit' 'json-c'
-  'krb5' 'libcap' 'libidn2' 'libmaxminddb' 'libnsl' 'libuv' 'libxml2' 'lmdb'
-  'openssl' 'readline' 'xz' 'zlib' 'libnghttp2' 'liburcu')
+depends=('bash' 'dnssec-anchors' 'e2fsprogs' 'glibc' 'icu' 'jemalloc' 'libedit'
+  'json-c' 'krb5' 'libcap' 'libidn2' 'libmaxminddb' 'libnsl' 'libuv' 'libxml2'
+  'lmdb' 'openssl' 'readline' 'xz' 'zlib' 'libnghttp2' 'liburcu')
 makedepends=('git' 'python-sphinx')
 conflicts=('bind-tools' 'dnsutils')
 replaces=('bind-tools' 'dnsutils' 'host')

--- a/jemalloc/.SRCINFO
+++ b/jemalloc/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = jemalloc
 	pkgdesc = General-purpose scalable concurrent malloc implementation
 	pkgver = 5.3.0
-	pkgrel = 5
+	pkgrel = 6
 	epoch = 1
 	url = https://jemalloc.net/
 	arch = x86_64

--- a/jemalloc/PKGBUILD
+++ b/jemalloc/PKGBUILD
@@ -6,7 +6,7 @@
 pkgname=jemalloc
 epoch=1
 pkgver=5.3.0
-pkgrel=5
+pkgrel=6
 pkgdesc='General-purpose scalable concurrent malloc implementation'
 arch=(x86_64 powerpc64le powerpc64 powerpc riscv64)
 license=('BSD')
@@ -25,9 +25,15 @@ build() {
   # FS#71745: GCC-built jemalloc causes telegram-desktop to crash a lot. The reason is still not clear.
   export CC=clang
   export CXX=clang++
-
+  case ${CARCH} in
+    "powerpc64le")
+      USE_64K_PAGES=--with-lg-page=16
+	;;
+  esac
+  USE_64K_PAGES=--with-lg-page=16
   ./configure \
     --enable-prof \
+    $USE_64K_PAGES \
     --enable-autogen \
     --prefix=/usr
   make

--- a/jemalloc/PKGBUILD
+++ b/jemalloc/PKGBUILD
@@ -30,7 +30,6 @@ build() {
       USE_64K_PAGES=--with-lg-page=16
 	;;
   esac
-  USE_64K_PAGES=--with-lg-page=16
   ./configure \
     --enable-prof \
     $USE_64K_PAGES \


### PR DESCRIPTION
@techflashYT noticed that [jemalloc is only checking whether the system page size is larger than what jemalloc was built for](https://github.com/jemalloc/jemalloc/blob/499f3068593ec61dae961e2c8ea3e0cf1482d616/src/pages.c#L774).

I've tested this PR and it builds/runs on ppc64le on both 64k and 4k kernels. Change should not affect other platforms.