### PR TITLE
sdl3: fix autovectorization w/ altivec on 750/60x

### DIFF
--- a/sdl3/0001-no-autovectorize.patch
+++ b/sdl3/0001-no-autovectorize.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt	2025-05-13 21:24:40.000000000 +0000
++++ b/CMakeLists.txt	2025-07-05 07:56:47.215265603 +0000
+@@ -873,6 +873,7 @@
+         set(HAVE_ALTIVEC TRUE)
+         set(SDL_ALTIVEC_BLITTERS 1)
+         sdl_compile_options(PRIVATE "-maltivec")
++        sdl_compile_options(PRIVATE "-fno-tree-vectorize")
+         set_property(SOURCE "${SDL3_SOURCE_DIR}/src/video/SDL_blit_N.c" APPEND PROPERTY COMPILE_DEFINITIONS "SDL_ENABLE_ALTIVEC")
+         set_property(SOURCE "${SDL3_SOURCE_DIR}/src/video/SDL_blit_N.c" PROPERTY SKIP_PRECOMPILE_HEADERS 1)
+       endif()

--- a/sdl3/PKGBUILD
+++ b/sdl3/PKGBUILD
@@ -45,10 +45,19 @@ optdepends=(
   'sndio: sndio audio driver'
   'libdecor: Wayland client decorations'
 )
-source=("https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL3-${pkgver}.tar.gz"{,.sig})
+source=(
+  "https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL3-${pkgver}.tar.gz"{,.sig}
+  "0001-no-autovectorize.patch"
+)
 sha512sums=('7e501bda73cc7b42b860e6ba6f9a0450fdb5014f5999afa64ccd6b4eb633edf6646fd1e251d58189649755a883d7dd51e5bcc53e841974180ed73d56fb8e29cd'
-            'SKIP')
+            'SKIP'
+            '46195bb8352389bece6509c4aaf8860eafa7277944ed7cbfac27ac2da53ee149747df57b6269c24ee8f621e9a75d907151626f25258c3598006aa0d14f43bb42')
 validpgpkeys=('1528635D8053A57F77D1E08630A59377A7763BE6') # Sam Lantinga
+
+prepare() {
+  cd "${srcdir}/SDL3-${pkgver}"
+  patch -p1 < ../0001-no-autovectorize.patch
+}
 
 build() {
   CFLAGS+=" -ffat-lto-objects"


### PR DESCRIPTION
This patch has also been submitted to upstream SDL, but it's offered here if you want the current builds to work on PPC750/60x until that patch gets merged into an official release.