### PR TITLE
Allow building toolchain on x86_64

### DIFF
--- a/cross-compilers/powerpc-unknown-linux-gnu-gcc-stage1/PKGBUILD
+++ b/cross-compilers/powerpc-unknown-linux-gnu-gcc-stage1/PKGBUILD
@@ -111,6 +111,4 @@ package() {
 
   # strip it manually
   strip "$pkgdir/usr/bin/"* 2>/dev/null || true
-  find "$pkgdir/usr/lib" -type f -exec /usr/bin/${_target}-strip \
-    --strip-unneeded {} \; 2>/dev/null || true
 }

--- a/cross-compilers/powerpc-unknown-linux-gnu-gcc-stage2/PKGBUILD
+++ b/cross-compilers/powerpc-unknown-linux-gnu-gcc-stage2/PKGBUILD
@@ -110,6 +110,4 @@ package() {
 
   # strip it manually
   strip "$pkgdir/usr/bin/"* 2>/dev/null || true
-  find "$pkgdir/usr/lib" -type f -exec /usr/bin/${_target}-strip \
-    --strip-unneeded {} \; 2>/dev/null || true
 }

--- a/cross-compilers/powerpc-unknown-linux-gnu-gcc/PKGBUILD
+++ b/cross-compilers/powerpc-unknown-linux-gnu-gcc/PKGBUILD
@@ -112,8 +112,6 @@ package() {
 
   # strip it manually
   strip "$pkgdir/usr/bin/"* 2>/dev/null || true
-  find "$pkgdir/usr/lib" -type f -exec /usr/bin/${_target}-strip \
-    --strip-unneeded {} \; 2>/dev/null || true
 
   install -d -m 755 "$pkgdir/usr/$_target/usr/lib"
   mv "$pkgdir/usr/$_target/lib" "$pkgdir/usr/$_target/usr/"

--- a/cross-compilers/powerpc-unknown-linux-gnu-libxcrypt/PKGBUILD
+++ b/cross-compilers/powerpc-unknown-linux-gnu-libxcrypt/PKGBUILD
@@ -16,8 +16,8 @@ arch=(any)
 url='https://github.com/besser82/libxcrypt'
 license=('LGPL')
 depends=("${_target}-glibc>=2.41")
-makedepends=("${_target}-gcc")
-options=(!debug)
+makedepends=("${_target}-gcc-stage2")
+options=(!debug !lto)
 validpgpkeys=('678CE3FEE430311596DB8C16F52E98007594C21D') # Björn 'besser82' Esser
 source=("${url}/releases/download/v${pkgver}/libxcrypt-${pkgver}.tar.xz"{,.asc})
 sha256sums=('80304b9c306ea799327f01d9a7549bdb28317789182631f1b54f4511b4206dd6'


### PR DESCRIPTION
Issues resolved:

* Stripping binaries in /usr/lib is disabled. It wasn't working for two reasons:
     * It's not generally safe to use powerpc-unknown-linux-gnu-strip on an ELF x86_64 binary
     * It's not safe to strip static archives or object files
* libxcrypt has a circular dependency on final gcc. I turned it into a gcc-stage2 dependency.
* libxcrypt can't be built against gcc-stage2 with LTO, so I turned off LTO.

Improvements we could consider, but might take more work:

* Keep stripping in /usr/lib, but use host-strip, and exclude `.o` and `.a` files (and any others that aren't safe to strip). Would take some experimenting to figure out what's safe.
* Build a libxcrypt-stage1 without LTO which depends on gcc-stage2; and then a final libxcrypt with LTO which depends on final gcc. But this adds extra steps with minimal benefit.
* Apply changes to all the other cross-compilers. Do you have some method of keeping all these cross-compiler package definitions in sync with each other?