### PR TITLE
linux-xenon: install kernel as vmlinuz as well + updates

### DIFF
--- a/kernels/powerpc/linux-xenon/.SRCINFO
+++ b/kernels/powerpc/linux-xenon/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = linux-xenon
 	pkgdesc = Linux (powerpc64 / Microsoft Xbox 360)
-	pkgver = 6.18
-	pkgrel = 2
+	pkgver = 6.18.11
+	pkgrel = 1
 	url = https://kernel.org
 	arch = any
 	license = GPL2
@@ -17,9 +17,9 @@ pkgbase = linux-xenon
 	options = !ccache
 	options = !debug
 	options = !strip
-	source = https://github.com/techflashYT/linux-custom/archive/5d05c918db80eaeee4194544e53296d71f54fb2e.tar.gz
+	source = https://github.com/techflashYT/linux-custom/archive/a293dd19311668900eb1eeb2f6cb01dcac54f330.tar.gz
 	source = config
-	sha256sums = 285b81d4c3674a8988eb0497bb4bf1406b429f59d8a60848e26b6aa324928677
+	sha256sums = b3e0b3a92523f334e594e07b57da58e459b4d21630ec1366aba48297da9282f0
 	sha256sums = d17aae9336e77f54b44488fa8e2cd23222a0f79afa7eb7c1a039271dcd4e5634
 
 pkgname = linux-xenon

--- a/kernels/powerpc/linux-xenon/.SRCINFO
+++ b/kernels/powerpc/linux-xenon/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = linux-xenon
 	pkgdesc = Linux (powerpc64 / Microsoft Xbox 360)
 	pkgver = 6.18
-	pkgrel = 1
+	pkgrel = 2
 	url = https://kernel.org
 	arch = any
 	license = GPL2

--- a/kernels/powerpc/linux-xenon/PKGBUILD
+++ b/kernels/powerpc/linux-xenon/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgbase=linux-xenon
 pkgver=6.18
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux (powerpc64 / Microsoft Xbox 360)'
 url='https://kernel.org'
 arch=(any)
@@ -92,9 +92,10 @@ _package() {
   local modulesdir="$pkgdir/usr/lib/modules/$(<version)"
 
   echo "Installing boot image..."
+  install -Dm644 arch/powerpc/boot/zImage.xenon "$modulesdir/zImage.xenon"
   # systemd expects to find the kernel here to allow hibernation
   # https://github.com/systemd/systemd/commit/edda44605f06a41fb86b7ab8128dcf99161d2344
-  install -Dm644 arch/powerpc/boot/zImage.xenon "$modulesdir/zImage.xenon"
+  install -Dm644 arch/powerpc/boot/zImage.xenon "$modulesdir/vmlinuz"
 
   # Used by mkinitcpio to name the kernel
   echo "$pkgbase" | install -Dm644 /dev/stdin "$modulesdir/pkgbase"

--- a/kernels/powerpc/linux-xenon/PKGBUILD
+++ b/kernels/powerpc/linux-xenon/PKGBUILD
@@ -3,8 +3,8 @@
 
 
 pkgbase=linux-xenon
-pkgver=6.18
-pkgrel=2
+pkgver=6.18.11
+pkgrel=1
 pkgdesc='Linux (powerpc64 / Microsoft Xbox 360)'
 url='https://kernel.org'
 arch=(any)
@@ -27,13 +27,13 @@ makedepends_riscv64=(powerpc64-unknown-linux-gnu-gcc)
 makedepends_x86_64=(powerpc64-unknown-linux-gnu-gcc)
 
 options=('!ccache' '!debug' '!strip')
-_commit=5d05c918db80eaeee4194544e53296d71f54fb2e
+_commit=a293dd19311668900eb1eeb2f6cb01dcac54f330
 _srcname=linux-custom-${_commit}
 source=(
   https://github.com/techflashYT/linux-custom/archive/${_commit}.tar.gz
   config  # the main kernel config file
 )
-sha256sums=('285b81d4c3674a8988eb0497bb4bf1406b429f59d8a60848e26b6aa324928677'
+sha256sums=('b3e0b3a92523f334e594e07b57da58e459b4d21630ec1366aba48297da9282f0'
             'd17aae9336e77f54b44488fa8e2cd23222a0f79afa7eb7c1a039271dcd4e5634')
 
 export KBUILD_BUILD_HOST=archpower


### PR DESCRIPTION
This lets it get automatically installed to /boot, and a ramdisk get made.  This is particularly useful for archiso usage.
Also updates the kernel to 6.18.11, which notably also includes the change that drops AltiVec from the reported feature list.