### PR TITLE
Disable Altivec on all files except the one that uses it

### DIFF
--- a/sdl3/0002-altivec.patch
+++ b/sdl3/0002-altivec.patch
@@ -1,0 +1,16 @@
+diff --git i/CMakeLists.txt w/CMakeLists.txt
+index b01acc3bc..f47d1f814 100644
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -923,10 +923,9 @@ if(SDL_ASSEMBLY)
+       if(COMPILER_SUPPORTS_ALTIVEC)
+         set(HAVE_ALTIVEC TRUE)
+         set(SDL_ALTIVEC_BLITTERS 1)
+-        sdl_compile_options(PRIVATE "-maltivec")
+-        sdl_compile_options(PRIVATE "-fno-tree-vectorize")
+         set_property(SOURCE "${SDL3_SOURCE_DIR}/src/video/SDL_blit_N.c" APPEND PROPERTY COMPILE_DEFINITIONS "SDL_ENABLE_ALTIVEC")
+         set_property(SOURCE "${SDL3_SOURCE_DIR}/src/video/SDL_blit_N.c" PROPERTY SKIP_PRECOMPILE_HEADERS 1)
++        set_source_files_properties(src/video/SDL_blit_N.c PROPERTIES COMPILE_FLAGS "-maltivec -fno-tree-vectorize")
+       endif()
+     endif()
+ 

--- a/sdl3/PKGBUILD
+++ b/sdl3/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Sven-Hendrik Haase <svenstaro@archlinux.org>
 pkgname=sdl3
 pkgver=3.4.4
-pkgrel=1
+pkgrel=2
 pkgdesc="A library for portable low-level access to a video framebuffer, audio output, mouse, and keyboard (Version 3)"
 arch=(x86_64 powerpc64le powerpc64 powerpc espresso)
 url="https://www.libsdl.org"
@@ -45,10 +45,17 @@ optdepends=(
   'sndio: sndio audio driver'
   'libdecor: Wayland client decorations'
 )
-source=("https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL3-${pkgver}.tar.gz"{,.sig})
+source=("https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL3-${pkgver}.tar.gz"{,.sig}
+        0002-altivec.patch)
 sha512sums=('2c28a10c49f79efcfbb486156e7271b84cca028b3d6d8b436e99c3be85e5e648aa6543387817b3281ae9f4fcc6cb4046d998c7b273e62d3d9fe76e019ac91b6e'
-            'SKIP')
+            'SKIP'
+            '23dda92c9e6cc712723deff87a55d3798600c09baf0daae14c0bff9b58bbc8c7008f640efad78f8af618c6e8dbb8a246483af0420d957c61ca1cc9f8c15b1e88')
 validpgpkeys=('0900104363B4C9D4223DE149D913FE7D4B61D39B') # Sam Lantinga
+
+prepare() {
+  cd SDL3-${pkgver}
+  patch -p1 < ${srcdir}/0002-altivec.patch
+}
 
 build() {
   CFLAGS+=" -ffat-lto-objects"


### PR DESCRIPTION
Even with -fno-tree-vectorize, we're getting occasional Altivec instructions for things like memset. We're only using Altivec intentionally in one file, so just turn it on specifically for that one, rather than everywhere.

With this, I'm able to run a basic SDL3 example (`examples/rendering/02-primitives/primitives.c`).